### PR TITLE
Slay a multitude of blunders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC?=gcc
-CFLAGS+=-Wall -Wextra -Wpedantic -std=c11
+CFLAGS+=-Wall -Wextra -Wpedantic -std=gnu11
 SRCDIR?=src
 OBJDIR?=obj
 BINDIR?=bin

--- a/examples/fraction.sq
+++ b/examples/fraction.sq
@@ -2,10 +2,10 @@ form Fraction {
 	matter numer, denom;
 
 	recollect coerce(what) {
-		if kindof(what) == Fraction {
+		if genus(what) == Fraction {
 			reward what
 		} alas {
-			reward Fraction(number(what), I)
+			reward Fraction(tally(what), I)
 		}
 	}
 

--- a/examples/robinhood.sq
+++ b/examples/robinhood.sq
@@ -4,19 +4,19 @@ form RobinHood {
 	matter weapon
 
 	# constructor
-	substantiate(weapon) {
+	imitate(weapon) {
 		my.weapon = weapon
 	}
 
 	# member function
-	action steal_from(whom) {
+	change steal_from(whom) {
 		proclaim("Hello, \(whom.name)\n")
 		proclaim("Give me your money or i'll shoot you with my \(my.weapon)\n")
 		reward whom.take()
 	}
 
 	# class function
-	describe please_help() {
+	recollect please_help() {
 		proclaim("Oh, robinhood, please help us!\n");
 	}
 }
@@ -26,7 +26,7 @@ form Rich {
 	matter money, name
 
 	# member function
-	journey take() {
+	change take() {
 		money = my.money
 		my.money = 0
 		reward money

--- a/examples/times.sq
+++ b/examples/times.sq
@@ -5,7 +5,7 @@ journey timestr(time) {
 
 	rawhours = time / 2;
 
-	if rawhours % 12 { hours = string(rawhours % 12) }
+	if rawhours % 12 { hours = arabic(rawhours % 12) }
 	alas { hours = "12"};
 
 	if rawhours >= 12 { ampm = "pm" }

--- a/src/function.c
+++ b/src/function.c
@@ -248,8 +248,10 @@ sq_value sq_function_run(struct sq_function *function, unsigned argc, sq_value *
 				size_t cap, length;
 
 				if ((length = getline(&line, &cap, stdin)) == (size_t) -1) {
+					free(line);
 					line = strdup("");
 					cap = 0;
+					length = 0;
 				}
 
 				if (length && line[length-1] == '\n') {

--- a/src/function.c
+++ b/src/function.c
@@ -104,7 +104,7 @@ sq_value sq_function_run(struct sq_function *function, unsigned argc, sq_value *
 	unsigned ip = 0;
 
 	while (true) {
-		if (ip == function->codelen) {
+		if (ip >= function->codelen) {
 			value = SQ_NULL;
 			goto done;
 		}

--- a/src/roman.c
+++ b/src/roman.c
@@ -71,7 +71,7 @@ char *sq_number_to_roman(sq_number number) {
 // note that this returns an owned string.
 char *sq_number_to_arabic(sq_number number) {
 	char *buf = xmalloc(40);
-	snprintf(buf, 40, "%lld", number);
+	snprintf(buf, 40, "%"PRId64, number);
 	return buf;
 }
 

--- a/src/roman.c
+++ b/src/roman.c
@@ -2,6 +2,7 @@
 #include "shared.h"
 #include <ctype.h>
 #include <string.h>
+#include <inttypes.h>
 
 enum roman_numeral {
 	SQ_TK_ROMAN_I = 1,

--- a/src/value.c
+++ b/src/value.c
@@ -7,6 +7,7 @@
 #include "roman.h"
 #include "codex.h"
 #include <string.h>
+#include <inttypes.h>
 #include <limits.h>
 
 #define IS_STRING sq_value_is_string
@@ -436,20 +437,20 @@ sq_value sq_value_mul(sq_value lhs, sq_value rhs) {
 
 	case SQ_TSTRING: {
 		sq_number amnt = sq_value_to_number(rhs);
-		if (amnt < 0 || amnt >= UINT_MAX || (amnt * AS_STRING(lhs)->length) >= UINT_MAX) {
-			sq_throw("string multiplication by '%"PRId64"' is out of range", amnt);
-		}
-		if (amnt == 0 || AS_STRING(lhs)->length == 0) {
+		if (amnt == 0 || AS_STRING(lhs)->length == 0)
 			return sq_value_new_string(&sq_string_empty);
-		}
-		if (amnt == 1) {
+		if (amnt < 0 || amnt >= UINT_MAX || (amnt * AS_STRING(lhs)->length) >= UINT_MAX)
+			sq_throw("string multiplication by %"PRId64" is out of range", amnt);
+		if (amnt == 1)
 			return sq_value_new_string(sq_string_clone(AS_STRING(lhs)));
-		}
+
 		struct sq_string *result = sq_string_alloc(AS_STRING(lhs)->length * amnt);
 		char *ptr = result->ptr;
 
-		for (unsigned i = 0; i < amnt; ++i, ptr += AS_STRING(lhs)->length)
+		for (unsigned i = 0; i < amnt; ++i) {
 			memcpy(ptr, AS_STR(lhs), AS_STRING(lhs)->length + 1);
+			ptr += AS_STRING(lhs)->length;
+		}
 
 		return sq_value_new_string(result);
 	}

--- a/src/value.c
+++ b/src/value.c
@@ -7,6 +7,7 @@
 #include "roman.h"
 #include "codex.h"
 #include <string.h>
+#include <limits.h>
 
 #define IS_STRING sq_value_is_string
 #define AS_STRING sq_value_as_string
@@ -35,7 +36,7 @@ void sq_value_dump_to(FILE *out, sq_value value) {
 		break;
 
 	case SQ_TNUMBER:
-		fprintf(out, "Number(%lld)", AS_NUMBER(value));
+		fprintf(out, "Number(%"PRId64")", AS_NUMBER(value));
 		break;
 
 	case SQ_TSTRING:
@@ -63,7 +64,7 @@ void sq_value_dump_to(FILE *out, sq_value value) {
 		break;
 
 	default:
-		bug("<UNDEFINED: %lld>", value);
+		bug("<UNDEFINED: %"PRId64">", value);
 	}
 }
 
@@ -435,11 +436,20 @@ sq_value sq_value_mul(sq_value lhs, sq_value rhs) {
 
 	case SQ_TSTRING: {
 		sq_number amnt = sq_value_to_number(rhs);
-		struct sq_string *result = sq_string_alloc(AS_STRING(lhs)->length * amnt + 1);
-		*result->ptr = '\0';
+		if (amnt < 0 || amnt >= UINT_MAX || (amnt * AS_STRING(lhs)->length) >= UINT_MAX) {
+			sq_throw("string multiplication by '%"PRId64"' is out of range", amnt);
+		}
+		if (amnt == 0 || AS_STRING(lhs)->length == 0) {
+			return sq_value_new_string(&sq_string_empty);
+		}
+		if (amnt == 1) {
+			return sq_value_new_string(sq_string_clone(AS_STRING(lhs)));
+		}
+		struct sq_string *result = sq_string_alloc(AS_STRING(lhs)->length * amnt);
+		char *ptr = result->ptr;
 
-		for (unsigned i = 0; i < amnt; ++i)
-			strcat(result->ptr, AS_STR(lhs));
+		for (unsigned i = 0; i < amnt; ++i, ptr += AS_STRING(lhs)->length)
+			memcpy(ptr, AS_STR(lhs), AS_STRING(lhs)->length + 1);
 
 		return sq_value_new_string(result);
 	}
@@ -559,7 +569,7 @@ struct sq_string *sq_value_to_string(sq_value value) {
 		die("cannot convert %s to a string", TYPENAME(value));
 
 	default:
-		bug("<UNDEFINED: %lld>", value);
+		bug("<UNDEFINED: %"PRId64">", value);
 	}
 }
 
@@ -595,7 +605,7 @@ sq_number sq_value_to_number(sq_value value) {
 		die("cannot convert %s to a number", TYPENAME(value));
 
 	default:
-		bug("<UNDEFINED: %lld>", value);
+		bug("<UNDEFINED: %"PRId64">", value);
 	}
 }
 
@@ -633,8 +643,7 @@ bool sq_value_to_boolean(sq_value value) {
 		die("cannot convert %s to a boolean", TYPENAME(value));
 
 	default:
-*		(volatile int *)0;
-		bug("<UNDEFINED: %lld>", value);
+		bug("<UNDEFINED: %"PRId64">", value);
 	}
 }
 
@@ -668,7 +677,7 @@ size_t sq_value_length(sq_value value) {
 		die("cannot get length of %s", TYPENAME(value));
 
 	default:
-		bug("<UNDEFINED: %lld>", value);
+		bug("<UNDEFINED: %"PRId64">", value);
 	}
 }
 


### PR DESCRIPTION
- fix and optimize string multiplication
- begone with thine foolish fraktur parsing
- fix segfault with comefrom without any `whence`
- update some examples
- fix Makefile disabling strdup
- fix annoying `-Wformat` warnings